### PR TITLE
fix(proxy): use correct trap for delete

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,11 +73,12 @@ const proxyHandler = {
   set (obj, prop, value) {
     if (prop.slice(0, 2) === '__') {
       obj[prop] = value
+      return true
     } else {
       throw new Error('figgyPudding options cannot be modified. Use .concat() instead.')
     }
   },
-  delete () {
+  deleteProperty () {
     throw new Error('figgyPudding options cannot be deleted. Use .concat() and shadow them instead.')
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -163,4 +163,38 @@ test('concat', t => {
   t.done()
 })
 
+test('proxy', t => {
+  const testOpts = puddin({
+    a: {},
+    b: {}
+  })
+  let opts = testOpts({a: 1})
+  t.equal('a' in opts, true, 'provided opt detected')
+  t.equal('b' in opts, false, 'missing opt undetected')
+  t.equal('c' in opts, false, 'undefined opt undetected')
+  t.equal(opts.a, 1, 'provided key retrieved')
+  t.doesNotThrow(
+    () => {
+      opts.__woo = 'woo'
+    },
+    'setting private keys is possible'
+  )
+  t.equal(opts.__woo, 'woo', 'private key retrieved')
+  t.throws(
+    () => {
+      opts.b = 'yo'
+    },
+    /figgyPudding options cannot be modified/i,
+    'setting non-private keys is forbidden'
+  )
+  t.throws(
+    () => {
+      delete opts.a
+    },
+    /figgyPudding options cannot be deleted/i,
+    'deleting keys is forbidden'
+  )
+  t.done()
+})
+
 test('is delicious and figgy')


### PR DESCRIPTION
The `delete` trap is actually named [deleteProperty][1], and [set][2] needs to `return true` when successful. I added tests, too, so maybe the coverage will stop reporting "failure"?

[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/deleteProperty
[2]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/set