### PR TITLE
add typescript definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,24 @@ const MyAppOpts = figgyPudding({
 })
 ```
 
+##### `opts`
+
+###### `other(key: String) -> Boolean`
+
+Additional keys can be allowed, if they pass the test in this function
+
+###### Example
+
+```javascript
+const MyOtherOpts = puddin({
+  a: {}
+}, {
+  other (key) { return /^special-/.test(key) }
+})
+```
+
+This will allow values that start with `special-`
+
 #### <a name="pudding-factory"></a> `> PuddingFactory(...providers) -> FiggyPudding{}`
 
 Instantiates an options object defined by `figgyPudding()`, which uses

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,8 @@ declare function figgyPudding<
 >(specs?: S, opts?: O): figgyPudding.PuddingFactory<S, O>
 
 declare module figgyPudding {
+  type Flatten<T extends [any, ...any[]]> = T extends [infer H] ? H : {} 
+
   interface Options {
     other?(key: string): boolean
   }
@@ -38,9 +40,9 @@ declare module figgyPudding {
     [key: string]: unknown
   } : {})
 
-  type ProxyFiggyPudding<S, O> = Readonly<Proxy<S, O>> & FiggyPudding<S, O>
+  type ProxyFiggyPudding<S, O, P = {}> = Readonly<Proxy<S, O>> & FiggyPudding<S, O>
 
-  type PuddingFactory<S, O> = (...providers: any[]) => ProxyFiggyPudding<S, O>
+  type PuddingFactory<S, O> = <T extends any[]>(...providers: T) => ProxyFiggyPudding<S, O, P>
 
   interface FiggyPuddingConstructor {
     new <S extends Specs, O extends Options>(
@@ -53,7 +55,8 @@ declare module figgyPudding {
     readonly [Symbol.toStringTag]: 'FiggyPudding'
 
     get<K extends AvailableKeys<S, O>>(key: K): K extends keyof S ? SpecDefault<S[K]> : unknown
-    concat<P extends any[]>(...providers: P): ProxyFiggyPudding<S, O>
+    concat<P extends any[]>(...providers: ): ProxyFiggyPudding<S, O, P>
+    concat(...providers: any[]): ProxyFiggyPudding<S, O>
     toJSON(): {
       [K in AvailableKeys<S, O>]: K extends keyof S ? SpecDefault<S[K]> : unknown
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,72 @@
+
+declare function figgyPudding<
+  S extends figgyPudding.Specs = {},
+  O extends figgyPudding.Options = {}
+>(specs?: S, opts?: O): figgyPudding.PuddingFactory<S, O>
+
+declare module figgyPudding {
+  interface Options {
+    other?(key: string): boolean
+  }
+
+  type OtherOpt = Required<Pick<Options, 'other'>>
+
+  type Specs = {
+    [K in string]: string | Spec
+  }
+  interface Spec {
+    default?: any
+  }
+
+  type SpecWithDefault = Required<Pick<Spec, 'default'>>
+  type WidenPrimitive<T> =
+    T extends string ? string :
+    T extends number ? number :
+    T extends boolean ? boolean :
+    T
+  type SpecDefault<S> = S extends {default(): infer R} ? WidenPrimitive<R> : S extends {default: infer D} ? D : unknown
+
+  interface MapLike<K, V> {
+    get(key: K): V | undefined
+  }
+
+  type AvailableKeys<S, O> = O extends OtherOpt ? string : keyof S
+
+  type Proxy<S, O> = {
+    [K in keyof S]: SpecDefault<S[K]>
+  } & (O extends {other(key: string): boolean} ? {
+    [key: string]: unknown
+  } : {})
+
+  type ProxyFiggyPudding<S, O> = Readonly<Proxy<S, O>> & FiggyPudding<S, O>
+
+  type PuddingFactory<S, O> = (...providers: any[]) => ProxyFiggyPudding<S, O>
+
+  interface FiggyPuddingConstructor {
+    new <S extends Specs, O extends Options>(
+      specs: S, opts: O, providers: any[]
+    ): FiggyPudding<S, O>
+  }
+
+  interface FiggyPudding<S, O> {
+    readonly __isFiggyPudding: true
+    readonly [Symbol.toStringTag]: 'FiggyPudding'
+
+    get<K extends AvailableKeys<S, O>>(key: K): K extends keyof S ? SpecDefault<S[K]> : unknown
+    concat<P extends any[]>(...providers: P): ProxyFiggyPudding<S, O>
+    toJSON(): {
+      [K in AvailableKeys<S, O>]: K extends keyof S ? SpecDefault<S[K]> : unknown
+    }
+    forEach<This = this>(
+      fn: (this: This, value: unknown, key: AvailableKeys<S, O>, opts: this) => void,
+      thisArg?: This
+    ): void
+    entries(matcher: (key: string) => boolean): IterableIterator<[string, unknown]>
+    entries(): IterableIterator<[AvailableKeys<S, O>, unknown]>
+    [Symbol.iterator](): IterableIterator<[AvailableKeys<S, O>, unknown]>
+    keys(): IterableIterator<AvailableKeys<S, O>>
+    values(): IterableIterator<unknown>
+  }
+}
+
+export = figgyPudding

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.5.1",
   "description": "Delicious, festive, cascading config/opts definitions",
   "main": "index.js",
+  "types": "index.d.ts",
   "files": [
     "*.js",
     "lib"

--- a/test/iteration.js
+++ b/test/iteration.js
@@ -21,6 +21,11 @@ test('forEach', t => {
     [1, 'a', opts],
     [2, 'b', opts]
   ], 'correct arguments, and only declared props, in declared order')
+
+  opts.forEach(function () {
+    thisArg = this
+  })
+  t.equal(thisArg, opts, 'correct default this')
   t.done()
 })
 

--- a/test/typedef.ts
+++ b/test/typedef.ts
@@ -1,0 +1,172 @@
+import * as puddin from '../index'
+
+const test = (title: string, fn: (t: any) => void) => {}
+
+test('forEach', t => {
+  const testOpts = puddin({
+    a: {},
+    b: {}
+  })
+  const arr = []
+  let thisArg
+  const expectedThis = {}
+  const opts = testOpts({a: 1, b: 2, c: 3})
+  opts.forEach(function (...args) {
+    thisArg = this
+    arr.push(args)
+  }, expectedThis)
+  t.equal(thisArg, expectedThis, 'correct thisArg')
+  opts.forEach(function (...args) {
+    thisArg = this
+    arr.push(args)
+  })
+  t.equal(thisArg, opts, 'correct default this')
+  t.deepEqual(arr, [
+    [1, 'a', opts],
+    [2, 'b', opts]
+  ], 'correct arguments, and only declared props, in declared order')
+  t.done()
+})
+
+test('entries', t => {
+  const testOpts = puddin({
+    a: {},
+    b: {}
+  })
+  const arr = []
+  const opts = testOpts({a: 1, b: 2, c: 3})
+  for (let [key, value] of opts.entries()) {
+    arr.push([key, value])
+  }
+  t.deepEqual(arr, [
+    ['a', 1],
+    ['b', 2]
+  ], 'correct arguments, and only declared props, in declared order')
+  t.done()
+})
+
+test('entries over nested puddings', t => {
+  const testOpts = puddin({
+    a: {},
+    b: {}
+  })
+  const nestedOpts = puddin({}) // actual values declared should not matter
+  const arr = []
+  const opts = testOpts({a: 1}).concat(
+    {b: 3},
+    nestedOpts({}).concat(nestedOpts({b: 2}))
+  )
+  for (let [key, value] of opts.entries()) {
+    arr.push([key, value])
+  }
+  t.deepEqual(arr, [
+    ['a', 1],
+    ['b', 2]
+  ], 'reaches into nested puddings even if they don\'t declare a key')
+  testOpt
+  t.done()
+})
+
+test('Symbol.iterator', t => {
+  const testOpts = puddin({
+    a: {},
+    b: {}
+  })
+  const arr = []
+  const opts = testOpts({a: 1, b: 2, c: 3})
+  for (let [key, value] of opts) {
+    arr.push([key, value])
+  }
+  t.deepEqual(arr, [
+    ['a', 1],
+    ['b', 2]
+  ], 'pudding itself is an iterator')
+  t.done()
+})
+
+test('keys', t => {
+  const testOpts = puddin({
+    a: {},
+    b: {}
+  })
+  const arr = []
+  const opts = testOpts({a: 1, b: 2, c: 3})
+  for (let key of opts.keys()) {
+    arr.push(key)
+  }
+  t.deepEqual(arr, [
+    'a', 'b'
+  ], '.keys() iterates over keys')
+  t.done()
+})
+
+test('values', t => {
+  const testOpts = puddin({
+    a: {},
+    b: {}
+  })
+  const arr = []
+  const opts = testOpts({a: 1, b: 2, c: 3})
+  for (let key of opts.values()) {
+    arr.push(key)
+  }
+  t.deepEqual(arr, [
+    1, 2
+  ], '.values() iterates over values')
+  t.done()
+})
+
+test('opts.other iteration', t => {
+  const testOpts = puddin({
+    a: {}
+  }, {
+    other (key) { return /^special-/.test(key) }
+  })
+  const arr = []
+  const opts = testOpts({
+    'special-a': 3,
+    a: 1,
+    b: 2,
+    'special-b': 4,
+    'a-special': 5
+  })
+  for (let [key, value] of opts.entries()) {
+    arr.push([key, value])
+  }
+  t.deepEqual(arr, [
+    ['a', 1],
+    ['special-a', 3],
+    ['special-b', 4]
+  ], 'iterates over opts.other keys after primary keys')
+  t.done()
+})
+
+test('opts.other iteration over nested puddings', t => {
+  const testOpts = puddin({
+    a: {}
+  }, {
+    other (key) { return /^special-/.test(key) }
+  })
+  const nestedOpts = puddin({
+    b: {}
+  })
+  const arr = []
+  const opts = testOpts({
+    'special-b': 4
+  }).concat({a: 3}, nestedOpts({
+    a: 1,
+    'a-special': 5
+  }).concat(nestedOpts({
+    b: 2,
+    'special-a': 3
+  })))
+  for (let [key, value] of opts.entries()) {
+    arr.push([key, value])
+  }
+  t.deepEqual(arr, [
+    ['a', 1],
+    ['special-a', 3],
+    ['special-b', 4]
+  ], 'expected order even with nested opts.others')
+  t.done()
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "strict": true
+  }
+}


### PR DESCRIPTION
The focus of this PR is to add type definitions for typescript. Minimum typescript version supported is 3.0.0 (as figgy pudding is very fancy)

This PR adds documentation for `other` and one extra test for `this` in forEach. These changes can be split into other PRs if you want to review them separately.